### PR TITLE
Laravel 12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
   "require": {
     "php": "^8.2",
     "guzzlehttp/guzzle": "^7.0",
-    "laravel/framework": "^11.0" ,
+    "laravel/framework": "^11.0 || ^12.0" ,
     "omniphx/forrest": "^2.0"
   },
   "require-dev": {
     "laravel/dusk": "^8.0",
-    "orchestra/testbench": "^9.0",
+    "orchestra/testbench": "^9.0 || ^10.0",
     "phpunit/phpunit": ">=10.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "rob-lester-jr04/eloquent-sales-force",
+  "name": "pabloldias/eloquent-sales-force",
   "description": "An eloquent model data source for Salesforce",
   "license": "MIT",
   "keywords": [
@@ -17,27 +17,31 @@
     {
       "name": "Robert Lester",
       "email": "roblesterjr04@gmail.com"
+    },
+    {
+      "name": "Pablo Dias",
+      "email": "pablo.dias@pfizer.com"
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1",
-    "guzzlehttp/guzzle": "^6.0 || ^7.0",
-    "laravel/framework": "^6.0 || ^7.0 || ^8.40.0 || ^9.0 || ^10.0 || ^11.0" ,
+    "php": "^8.2",
+    "guzzlehttp/guzzle": "^7.0",
+    "laravel/framework": "^11.0" ,
     "omniphx/forrest": "^2.0"
   },
   "require-dev": {
-    "laravel/dusk": "^6.19 || ^7.0 || ^8.0",
-    "orchestra/testbench": "^3.8 || ^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
-    "phpunit/phpunit": ">=6.0 || >=10.0"
+    "laravel/dusk": "^8.0",
+    "orchestra/testbench": "^9.0",
+    "phpunit/phpunit": ">=10.0"
   },
   "autoload": {
     "psr-4": {
-      "Lester\\EloquentSalesForce\\": "src"
+      "PabloDias\\EloquentSalesForce\\": "src"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Lester\\EloquentSalesForce\\Tests\\": "tests"
+      "PabloDias\\EloquentSalesForce\\Tests\\": "tests"
     },
     "files": [
       "vendor/phpunit/phpunit/src/Framework/Assert/Functions.php"
@@ -53,7 +57,7 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Lester\\EloquentSalesForce\\ServiceProvider"
+        "PabloDias\\EloquentSalesForce\\ServiceProvider"
       ]
     }
   },

--- a/src/Console/MakeModelCommand.php
+++ b/src/Console/MakeModelCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Console;
+namespace PabloDias\EloquentSalesForce\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;

--- a/src/Console/SyncFromSalesforce.php
+++ b/src/Console/SyncFromSalesforce.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Console;
+namespace PabloDias\EloquentSalesForce\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;

--- a/src/Console/stubs/model.stub
+++ b/src/Console/stubs/model.stub
@@ -3,7 +3,7 @@
 namespace {{ namespace }};
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Lester\EloquentSalesForce\Model;
+use PabloDias\EloquentSalesForce\Model;
 
 class {{ class }} extends Model
 {

--- a/src/Database/SOQLBatch.php
+++ b/src/Database/SOQLBatch.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Database;
+namespace PabloDias\EloquentSalesForce\Database;
 
 use Session;
 use Log;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
-use Lester\EloquentSalesForce\SalesForceObject;
+use PabloDias\EloquentSalesForce\SalesForceObject;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
-use Lester\EloquentSalesForce\Database\SOQLBuilder as Builder;
-use Lester\EloquentSalesForce\Database\SOQLHasMany as HasMany;
-use Lester\EloquentSalesForce\Database\SOQLHasOne as HasOne;
-use Lester\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\Database\SOQLBuilder as Builder;
+use PabloDias\EloquentSalesForce\Database\SOQLHasMany as HasMany;
+use PabloDias\EloquentSalesForce\Database\SOQLHasOne as HasOne;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
 use Illuminate\Support\Collection;
 
 class SOQLBatch extends Collection

--- a/src/Database/SOQLBuilder.php
+++ b/src/Database/SOQLBuilder.php
@@ -2,17 +2,17 @@
 
 namespace PabloDias\EloquentSalesForce\Database;
 
+use Closure;
 use Illuminate\Database\Eloquent\Builder as Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Pagination\Paginator;
-use PabloDias\EloquentSalesForce\ServiceProvider;
-use PabloDias\EloquentSalesForce\Facades\SObjects;
-use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
-use PDO;
-use Closure;
+use Illuminate\Support\Str;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
 use PabloDias\EloquentSalesForce\Model;
-use Illuminate\Database\Eloquent\Relations\Relation;
+use PabloDias\EloquentSalesForce\ServiceProvider;
+use PDO;
 
 
 class SOQLBuilder extends Builder
@@ -28,7 +28,7 @@ class SOQLBuilder extends Builder
         //$pdo = new \Illuminate\Database\PDO\Connection($pdo);
 
 		$query->connection = new SOQLConnection();
-		$query->grammar = new SOQLGrammar();
+		$query->grammar = new SOQLGrammar($query->connection);
         $query->connection->setGrammar($query->grammar);
 
 		parent::__construct($query);

--- a/src/Database/SOQLBuilder.php
+++ b/src/Database/SOQLBuilder.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Database;
+namespace PabloDias\EloquentSalesForce\Database;
 
 use Illuminate\Database\Eloquent\Builder as Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Pagination\Paginator;
-use Lester\EloquentSalesForce\ServiceProvider;
-use Lester\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\ServiceProvider;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use PDO;
 use Closure;
-use Lester\EloquentSalesForce\Model;
+use PabloDias\EloquentSalesForce\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 

--- a/src/Database/SOQLConnection.php
+++ b/src/Database/SOQLConnection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Database;
+namespace PabloDias\EloquentSalesForce\Database;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\MySqlBuilder;
@@ -8,14 +8,14 @@ use Illuminate\Database\Query\Processors\MySqlProcessor;
 use Illuminate\Database\Query\Grammars\MySqlGrammar as QueryGrammar;
 use Illuminate\Database\Schema\Grammars\MySqlGrammar as SchemaGrammar;
 use Omniphx\Forrest\Exceptions\MissingResourceException;
-use Lester\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
 use Closure;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 use DateTimeInterface;
 use Illuminate\Support\Carbon as SupportCarbon;
 use Omniphx\Forrest\Exceptions\SalesforceException;
-use Lester\EloquentSalesForce\Exceptions;
+use PabloDias\EloquentSalesForce\Exceptions;
 
 class SOQLConnection extends Connection
 {

--- a/src/Database/SOQLGrammar.php
+++ b/src/Database/SOQLGrammar.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Database;
+namespace PabloDias\EloquentSalesForce\Database;
 
 use Carbon\Carbon;
 use Illuminate\Database\Query\Builder;
@@ -8,8 +8,8 @@ use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\JsonExpression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Lester\EloquentSalesForce\Facades\SObjects;
-use Lester\EloquentSalesForce\ServiceProvider;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\ServiceProvider;
 
 class SOQLGrammar extends Grammar
 {

--- a/src/Database/SOQLHasMany.php
+++ b/src/Database/SOQLHasMany.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Database;
+namespace PabloDias\EloquentSalesForce\Database;
 
 use Illuminate\Database\Eloquent\Collection;
-use Lester\EloquentSalesForce\Database\SOQLHasOneOrMany as HasOneOrMany;
+use PabloDias\EloquentSalesForce\Database\SOQLHasOneOrMany as HasOneOrMany;
 
 class SOQLHasMany extends HasOneOrMany
 {

--- a/src/Database/SOQLHasOne.php
+++ b/src/Database/SOQLHasOne.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Database;
+namespace PabloDias\EloquentSalesForce\Database;
 
 use Illuminate\Database\Eloquent\Collection;
-use Lester\EloquentSalesForce\Database\SOQLHasOneOrMany as HasOneOrMany;
+use PabloDias\EloquentSalesForce\Database\SOQLHasOneOrMany as HasOneOrMany;
 
 class SOQLHasOne extends HasOneOrMany
 {

--- a/src/Database/SOQLHasOneOrMany.php
+++ b/src/Database/SOQLHasOneOrMany.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Database;
+namespace PabloDias\EloquentSalesForce\Database;
 
-use Lester\EloquentSalesForce\Model;
-use Lester\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\Model;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Exceptions;
+namespace PabloDias\EloquentSalesForce\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Database\Eloquent\ModelNotFoundException;

--- a/src/Exceptions/MalformedQueryException.php
+++ b/src/Exceptions/MalformedQueryException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Exceptions;
+namespace PabloDias\EloquentSalesForce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/RequestLimitExceeded.php
+++ b/src/Exceptions/RequestLimitExceeded.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Exceptions;
+namespace PabloDias\EloquentSalesForce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/RestAPIException.php
+++ b/src/Exceptions/RestAPIException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Exceptions;
+namespace PabloDias\EloquentSalesForce\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/UnableToLockRowException.php
+++ b/src/Exceptions/UnableToLockRowException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Exceptions;
+namespace PabloDias\EloquentSalesForce\Exceptions;
 
 use Exception;
 

--- a/src/Facades/SObjects.php
+++ b/src/Facades/SObjects.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Facades;
+namespace PabloDias\EloquentSalesForce\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Lester\EloquentSalesForce\Fakers\SObjectsFake;
+use PabloDias\EloquentSalesForce\Fakers\SObjectsFake;
 
 class SObjects extends Facade
 {

--- a/src/Fakers/SObjectsFake.php
+++ b/src/Fakers/SObjectsFake.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Fakers;
+namespace PabloDias\EloquentSalesForce\Fakers;
 
-use Lester\EloquentSalesForce\SObjects;
+use PabloDias\EloquentSalesForce\SObjects;
 use PHPUnit\Framework\Assert as PHPUnit;
 
 class SObjectsFake

--- a/src/Model.php
+++ b/src/Model.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 use Session;
 use Log;
@@ -8,10 +8,10 @@ use Carbon\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
-use Lester\EloquentSalesForce\Database\SOQLBuilder as Builder;
-use Lester\EloquentSalesForce\Database\SOQLHasMany as HasMany;
-use Lester\EloquentSalesForce\Database\SOQLHasOne as HasOne;
-use Lester\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\Database\SOQLBuilder as Builder;
+use PabloDias\EloquentSalesForce\Database\SOQLHasMany as HasMany;
+use PabloDias\EloquentSalesForce\Database\SOQLHasOne as HasOne;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
 
 abstract class Model extends EloquentModel
 {
@@ -268,7 +268,7 @@ abstract class Model extends EloquentModel
 	 * @param  string  $related
 	 * @param  string  $foreignKey
 	 * @param  string  $localKey
-	 * @return \Lester\EloquentSalesForce\Database\SOQLHasMany
+	 * @return \PabloDias\EloquentSalesForce\Database\SOQLHasMany
 	 */
 	public function hasMany($related, $foreignKey = null, $localKey = null)
 	{
@@ -331,7 +331,7 @@ abstract class Model extends EloquentModel
 	 * @param  \Illuminate\Database\Eloquent\Model  $parent
 	 * @param  string  $foreignKey
 	 * @param  string  $localKey
-	 * @return \Lester\EloquentSalesForce\Database\SOQLHasMany
+	 * @return \PabloDias\EloquentSalesForce\Database\SOQLHasMany
 	 */
 	protected function newSOQLHasMany(Builder $query, Model $parent, $foreignKey, $localKey)
 	{

--- a/src/Observers/Syncronizer.php
+++ b/src/Observers/Syncronizer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Observers;
+namespace PabloDias\EloquentSalesForce\Observers;
 
 class Syncronizer
 {

--- a/src/SObjects.php
+++ b/src/SObjects.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 /** @scrutinizer ignore-call */use Forrest;
 use Omniphx\Forrest\Exceptions\MissingTokenException;
 use Omniphx\Forrest\Exceptions\MissingResourceException;
 use Omniphx\Forrest\Exceptions\MissingVersionException;
 use Omniphx\Forrest\Exceptions\SalesforceException;
-use Lester\EloquentSalesForce\Database\SOQLBatch;
+use PabloDias\EloquentSalesForce\Database\SOQLBatch;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use Cache;

--- a/src/SalesForceObject.php
+++ b/src/SalesForceObject.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 class SalesForceObject extends Model
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
-use Lester\EloquentSalesForce\Facades\SObjects as SfFacade;
+use PabloDias\EloquentSalesForce\Facades\SObjects as SfFacade;
 use Illuminate\Support\Arr;
-use Lester\EloquentSalesForce\Console\MakeModelCommand;
-use Lester\EloquentSalesForce\Console\SyncFromSalesforce;
-use Lester\EloquentSalesForce\TestLead;
-use Lester\EloquentSalesForce\TestObserver;
+use PabloDias\EloquentSalesForce\Console\MakeModelCommand;
+use PabloDias\EloquentSalesForce\Console\SyncFromSalesforce;
+use PabloDias\EloquentSalesForce\TestLead;
+use PabloDias\EloquentSalesForce\TestObserver;
 
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
@@ -53,7 +53,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
 
 		$loader = \Illuminate\Foundation\AliasLoader::getInstance();
 		$loader->alias('Forrest', 'Omniphx\Forrest\Providers\Laravel\Facades\Forrest');
-		$loader->alias('SObjects', 'Lester\EloquentSalesForce\Facades\SObjects');
+		$loader->alias('SObjects', 'PabloDias\EloquentSalesForce\Facades\SObjects');
 	}
 
 	/**

--- a/src/TestLead.php
+++ b/src/TestLead.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 class TestLead extends Model
 {

--- a/src/TestModel.php
+++ b/src/TestModel.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 use Illuminate\Database\Eloquent\Model;
-use Lester\EloquentSalesForce\Traits\SyncsWithSalesforce;
+use PabloDias\EloquentSalesForce\Traits\SyncsWithSalesforce;
 use Illuminate\Support\Str;
 
 class TestModel extends Model

--- a/src/TestObserver.php
+++ b/src/TestObserver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 class TestObserver
 {

--- a/src/TestTask.php
+++ b/src/TestTask.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 class TestTask extends Model
 {

--- a/src/TestUser.php
+++ b/src/TestUser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 class TestUser extends Model
 {

--- a/src/Traits/SyncsWithSalesforce.php
+++ b/src/Traits/SyncsWithSalesforce.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Traits;
+namespace PabloDias\EloquentSalesForce\Traits;
 
-use Lester\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
-use Lester\EloquentSalesForce\Observers\Syncronizer;
-use Lester\EloquentSalesForce\SalesForceObject;
+use PabloDias\EloquentSalesForce\Observers\Syncronizer;
+use PabloDias\EloquentSalesForce\SalesForceObject;
 
 trait SyncsWithSalesforce
 {


### PR DESCRIPTION
This pull request updates the package to change its namespace and vendor from `Lester\EloquentSalesForce` to `PabloDias\EloquentSalesForce`, reflecting new ownership and maintainership. It also updates the package requirements to support more recent versions of PHP and Laravel, and revises author information. These changes ensure future compatibility and proper attribution.

**Namespace and vendor migration:**

* All PHP files have their namespaces changed from `Lester\EloquentSalesForce` to `PabloDias\EloquentSalesForce`, including sub-namespaces for `Console`, `Database`, `Exceptions`, `Facades`, `Fakers`, `Observers`, and core files like `Model.php`. [[1]](diffhunk://#diff-365460fb0afd5ebac0bcc5df7b24c500d758f80785c2c6d24a1abb354ff0d47aL3-R3) [[2]](diffhunk://#diff-97590edbbc55cd8cc8f2c8359a7d282281c5097c71eaa5a655ddb64a2b1cee1dL3-R3) [[3]](diffhunk://#diff-5219a53a18f2601c5cfc6c7a4b72487a55cc2a26ecec7f977fbbc5ac26fdcb1aL3-R14) [[4]](diffhunk://#diff-80d1791e7133ba5e19ca988cbd3187140f8a1e5c383f98dae9cb79d63fa213adL3-L15) [[5]](diffhunk://#diff-25217a2bb9632de0612c7c63839d9c57f2c1a11b948dcb2133cd33ea05a4bf1dL3-R18) [[6]](diffhunk://#diff-e61d34af886aa95b58f32c141977fe450abf86793c0b1f843f8a0944b8627fb6L3-R12) [[7]](diffhunk://#diff-0639c3773a3817fbd3e9837095ac1c73cf425a478b93a7b240ae110faaff2835L3-R6) [[8]](diffhunk://#diff-8f4b115b30d040a88d3163308f597cbf76fa10db5907308f740152cbf2598bd8L3-R6) [[9]](diffhunk://#diff-6143aae788c62e11226fbedc99b2c441bd52f20a4895cb784659b4a47f17767dL3-R6) [[10]](diffhunk://#diff-10c9eeb8da57fe47faf03b60b11f5c9c23ed2cfda319c2f325dfdf35649554feL3-R3) [[11]](diffhunk://#diff-02c587cfab3202755eb0fd3f031bca55bccaf669b36466b29d4a49f8155202ceL3-R3) [[12]](diffhunk://#diff-233879629f45835433728f51f869ab2378585340744521f6ca6567ac1278fa9eL3-R3) [[13]](diffhunk://#diff-f0f3f9d688811a4615be52d34cd7ade36ad9f0d455e931bf3f98547a4112f69dL3-R3) [[14]](diffhunk://#diff-acdaa3fa6c7492dc90735a6b84b348219f9b3927e00331b6c44157c04c79fb05L3-R3) [[15]](diffhunk://#diff-2cb49d3bebd63629b721060a995a81f4d78314d9ede06f22615e33771cc8dfeeL3-R6) [[16]](diffhunk://#diff-2ff3c0b345704c24b149db8de30d80a37a2fbc35144a816862b18f60c26769e7L3-R5) [[17]](diffhunk://#diff-dcb1eeb6016633c008a6ca0a36d7c214146ecdc9979520a6922a506cb657a059L3-R14) [[18]](diffhunk://#diff-837e0bc9e556f2ce37d8b090b18959052b916b553834c7e1d20819aa2b553124L3-R3)

* Composer autoload and provider configuration updated to match the new namespace (`composer.json`). [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R20-R44) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L56-R60)

**Package ownership and attribution:**

* Package name in `composer.json` changed to `pabloldias/eloquent-sales-force` and author information updated to include Pablo Dias. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L2-R2) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R20-R44)

**Framework and dependency updates:**

* PHP requirement updated to `^8.2`, and Laravel requirement updated to `^11.0 || ^12.0`. Other dependencies such as `guzzlehttp/guzzle`, `laravel/dusk`, `orchestra/testbench`, and `phpunit/phpunit` also updated for newer versions.

**Code references and documentation:**

* All docblocks and references to the old namespace are updated to reflect the new namespace, ensuring consistency and reducing confusion for future maintainers. [[1]](diffhunk://#diff-d921decf15b2c9c6ecb2df99204215f5aa9d87e8245d65db9e66ed57cb300887L6-R6) [[2]](diffhunk://#diff-dcb1eeb6016633c008a6ca0a36d7c214146ecdc9979520a6922a506cb657a059L271-R271) [[3]](diffhunk://#diff-dcb1eeb6016633c008a6ca0a36d7c214146ecdc9979520a6922a506cb657a059L334-R334)

**Minor code improvements:**

* The constructor for `SOQLGrammar` now receives the connection as a parameter, improving initialization logic.