### PR TITLE
Rename package namespace in test suite

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,7 +102,7 @@ Replace the `use` statement so your model looks like:
 
 namespace App;
 
-use Lester\EloquentSalesForce\Model;
+use PabloDias\EloquentSalesForce\Model;
 
 class Lead extends Model
 {
@@ -383,10 +383,10 @@ Use this if you want to keep a local table, or just some fields, in sync with an
 ```php
 <?php
 
-namespace Lester\EloquentSalesForce;
+namespace PabloDias\EloquentSalesForce;
 
 use Illuminate\Database\Eloquent\Model;
-use Lester\EloquentSalesForce\Traits\SyncsWithSalesforce;
+use PabloDias\EloquentSalesForce\Traits\SyncsWithSalesforce;
 
 class SalesLead extends Model
 {
@@ -456,7 +456,7 @@ To use custom objects (or an object with a special object name, different from t
 
 namespace App;
 
-use Lester\EloquentSalesForce\Model;
+use PabloDias\EloquentSalesForce\Model;
 
 class TouchPoint extends Model
 {
@@ -575,7 +575,7 @@ $leads = collect($queryResult['records'])->map(function($record) {
 
 ```
 
-The class used for each object returned will be `Lester\EloquentSalesForce\SalesForceObject`.
+The class used for each object returned will be `PabloDias\EloquentSalesForce\SalesForceObject`.
 
 You can also query directly against the object like so:
 

--- a/tests/EloquentSalesForceTest.php
+++ b/tests/EloquentSalesForceTest.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Tests;
+namespace PabloDias\EloquentSalesForce\Tests;
 
-use Lester\EloquentSalesForce\ServiceProvider;
-use Lester\EloquentSalesForce\SalesForceObject;
-use Lester\EloquentSalesForce\TestLead;
-use Lester\EloquentSalesForce\TestModel;
-use Lester\EloquentSalesForce\TestTask;
-use Lester\EloquentSalesForce\TestUser;
+use PabloDias\EloquentSalesForce\ServiceProvider;
+use PabloDias\EloquentSalesForce\SalesForceObject;
+use PabloDias\EloquentSalesForce\TestLead;
+use PabloDias\EloquentSalesForce\TestModel;
+use PabloDias\EloquentSalesForce\TestTask;
+use PabloDias\EloquentSalesForce\TestUser;
 use Orchestra\Testbench\TestCase;
 use Illuminate\Support\Facades\Config;
-use Lester\EloquentSalesForce\Facades\SObjects;
-use Lester\EloquentSalesForce\Database\SOQLBatch;
+use PabloDias\EloquentSalesForce\Facades\SObjects;
+use PabloDias\EloquentSalesForce\Database\SOQLBatch;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Error\Notice;
@@ -21,8 +21,8 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Forrest;
 use GuzzleHttp\Client;
 use Carbon\Carbon;
-use Lester\EloquentSalesForce\Exceptions\MalformedQueryException;
-use Lester\EloquentSalesForce\Exceptions\RestAPIException;
+use PabloDias\EloquentSalesForce\Exceptions\MalformedQueryException;
+use PabloDias\EloquentSalesForce\Exceptions\RestAPIException;
 
 class EloquentSalesForceTest extends TestCase
 {
@@ -208,7 +208,7 @@ class EloquentSalesForceTest extends TestCase
             'eloquent_sf.syncTwoWay' => true,
             'eloquent_sf.syncPriority' => 'local',
             'eloquent_sf.syncTwoWayModels' => [
-                'Lester\EloquentSalesForce\TestModel',
+                'PabloDias\EloquentSalesForce\TestModel',
             ],
         ]);
 
@@ -271,8 +271,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /**
-     * @covers Lester\EloquentSalesForce\Database\SOQLBuilder::insert
-     * @covers Lester\EloquentSalesForce\SObjects::update
+     * @covers PabloDias\EloquentSalesForce\Database\SOQLBuilder::insert
+     * @covers PabloDias\EloquentSalesForce\SObjects::update
      */
     public function testObjectMass()
     {
@@ -317,9 +317,9 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /*
-	 * @covers Lester\EloquentSalesForce\Model
-	 * @covers Lester\EloquentSalesForce\Model::save
-	 * @covers Lester\EloquentSalesForce\Model::update
+	 * @covers PabloDias\EloquentSalesForce\Model
+	 * @covers PabloDias\EloquentSalesForce\Model::save
+	 * @covers PabloDias\EloquentSalesForce\Model::update
 	 */
     public function testObjectUpdate()
     {
@@ -351,8 +351,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /**
-	 * @covers Lester\EloquentSalesForce\Database\SOQLGrammar
-	 * @covers Lester\EloquentSalesForce\Database\SOQLGrammar::whereBasic
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar::whereBasic
 	 */
     public function testWhereBasic()
     {
@@ -373,8 +373,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /*
-     * @covers Lester\EloquentSalesForce\Database\SOQLGrammar
-     * @covers Lester\EloquentSalesForce\Database\SOQLGrammar::whereBoolean
+     * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar
+     * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar::whereBoolean
      */
     public function testWhereBoolean()
     {
@@ -385,8 +385,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /*
-     * @covers Lester\EloquentSalesForce\Database\SOQLGrammar
-     * @covers Lester\EloquentSalesForce\Database\SOQLGrammar::whereIn
+     * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar
+     * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar::whereIn
      */
     public function testWhereIn()
     {
@@ -411,8 +411,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /**
-	 * @covers Lester\EloquentSalesForce\Database\SOQLGrammar
-	 * @covers Lester\EloquentSalesForce\Database\SOQLGrammar::whereDate
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar::whereDate
 	 */
     public function testWhereDate()
     {
@@ -461,8 +461,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /*
-	 * @covers Lester\EloquentSalesForce\Model
-	 * @covers Lester\EloquentSalesForce\Model::delete
+	 * @covers PabloDias\EloquentSalesForce\Model
+	 * @covers PabloDias\EloquentSalesForce\Model::delete
 	 */
     public function testObjectDelete()
     {
@@ -474,11 +474,11 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /*
-	 * @covers Lester\EloquentSalesForce\Model
-	 * @covers Lester\EloquentSalesForce\Model::belongsTo
-	 * @covers Lester\EloquentSalesForce\Model::hasMany
-	 * @covers Lester\EloquentSalesForce\Database\SOQLHasMany
-	 * @covers Lester\EloquentSalesForce\Database\SOQLHasOneOrMany
+	 * @covers PabloDias\EloquentSalesForce\Model
+	 * @covers PabloDias\EloquentSalesForce\Model::belongsTo
+	 * @covers PabloDias\EloquentSalesForce\Model::hasMany
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLHasMany
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLHasOneOrMany
 	 */
     public function testRelationships()
     {
@@ -513,8 +513,8 @@ class EloquentSalesForceTest extends TestCase
     }*/
 
     /*
-	 * @covers Lester\EloquentSalesForce\Model
-	 * @covers Lester\EloquentSalesForce\Database\SOQLGrammar::compileJoins
+	 * @covers PabloDias\EloquentSalesForce\Model
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLGrammar::compileJoins
 	 */
     public function testJoins()
     {
@@ -533,8 +533,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /*
-	 * @covers Lester\EloquentSalesForce\Model
-	 * @covers Lester\EloquentSalesForce\Database\SOQLBuilder::paginate
+	 * @covers PabloDias\EloquentSalesForce\Model
+	 * @covers PabloDias\EloquentSalesForce\Database\SOQLBuilder::paginate
 	 */
     public function testPaginate()
     {
@@ -547,8 +547,8 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /*
-     * @covers Lester\EloquentSalesForce\Model::getPicklistValues
-     * @covers Lester\EloquentSalesForce\SObjects::getPicklistValues
+     * @covers PabloDias\EloquentSalesForce\Model::getPicklistValues
+     * @covers PabloDias\EloquentSalesForce\SObjects::getPicklistValues
      */
     public function testGetPicklistValues()
     {
@@ -579,10 +579,10 @@ class EloquentSalesForceTest extends TestCase
     }
 
     /**
-     * @covers Lester\EloquentSalesForce\SObjects::object
-     * @covers Lester\EloquentSalesForce\SObjects::convert
-     * @covers Lester\EloquentSalesForce\SObjects::is_uppercase
-     * @covers Lester\EloquentSalesForce\SObjects::describe
+     * @covers PabloDias\EloquentSalesForce\SObjects::object
+     * @covers PabloDias\EloquentSalesForce\SObjects::convert
+     * @covers PabloDias\EloquentSalesForce\SObjects::is_uppercase
+     * @covers PabloDias\EloquentSalesForce\SObjects::describe
      */
     public function testFacadeFuncs()
     {
@@ -593,7 +593,7 @@ class EloquentSalesForceTest extends TestCase
         $query = \Forrest::query('select Id from Lead limit 1');
 
         $object = SObjects::object($query['records'][0]);
-        $this->assertInstanceOf('Lester\EloquentSalesForce\SalesForceObject', $object);
+        $this->assertInstanceOf('PabloDias\EloquentSalesForce\SalesForceObject', $object);
 
         $testLeadFields = SObjects::describe('Product2');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Lester\EloquentSalesForce\Tests;
+namespace PabloDias\EloquentSalesForce\Tests;
 
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 


### PR DESCRIPTION
This pull request updates the namespace references throughout the codebase and documentation from `Lester\EloquentSalesForce` to `PabloDias\EloquentSalesForce`. The changes ensure consistency with the new package owner and prevent potential issues with autoloading or class resolution.

Namespace and class reference updates:

* Updated all `use` statements and class references in `docs/README.md` to use `PabloDias\EloquentSalesForce` instead of `Lester\EloquentSalesForce`. [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L105-R105) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L386-R389) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L459-R459) [[4]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938L578-R578)
* Refactored the test files (`tests/EloquentSalesForceTest.php`, `tests/TestCase.php`) to use the new namespace and class references, including all test annotations and assertions. [[1]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L3-R14) [[2]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L24-R25) [[3]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L211-R211) [[4]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L274-R275) [[5]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L320-R322) [[6]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L354-R355) [[7]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L376-R377) [[8]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L388-R389) [[9]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L414-R415) [[10]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L464-R465) [[11]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L477-R481) [[12]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L516-R517) [[13]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L536-R537) [[14]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L550-R551) [[15]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L582-R585) [[16]](diffhunk://#diff-4eed3ae641b9b7c779ee811ae2ba97b56158ed0ce85dc53a299579006abe1186L596-R596) [[17]](diffhunk://#diff-abf1fa77a19f720052b75bc802df0260157b9064d8c3c12a80794f01e9acc065L3-R3)